### PR TITLE
Updated KDL IK solver tip frame to tool0

### DIFF
--- a/config/workcell_plugins.yaml
+++ b/config/workcell_plugins.yaml
@@ -9,7 +9,7 @@ kinematic_plugins:
           class: KDLInvKinChainLMAFactory
           config:
             base_link: base_link
-            tip_link: tool_flange
+            tip_link: tool0
         IKFastInvKin:
           class: MotomanHC10InvKinFactory
           config:


### PR DESCRIPTION
Use the `tool0` frame as the tip link for the KDL IK solver such that other frames attached to `tool0` (e.g., `color_camera_optical_link`) can be used for motion planning